### PR TITLE
Small behavioral fixes

### DIFF
--- a/pkg/oktaApiAuth/oktaApiAuth.go
+++ b/pkg/oktaApiAuth/oktaApiAuth.go
@@ -17,7 +17,7 @@ import (
   "gopkg.in/algolia/okta-openvpn.v2/pkg/utils"
 )
 
-const userAgent string = "OktaOpenVPN/2.1.0 (Linux 5.4.0) Go-http-client/1.21.1"
+const userAgent string = "Mozilla/5.0 (Linux; x86_64) OktaOpenVPN/2.1.0"
 
 type OktaAPI = types.OktaAPI
 type OktaUserConfig = types.OktaUserConfig

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -16,6 +16,7 @@ type OktaAPI struct {
 type OktaUserConfig struct {
   Username  string
   Password  string
+  Passcode  string
   ClientIp  string
 }
 


### PR DESCRIPTION
- Passcode zttribute should be in OktaUserConfig struct
- Use cleaner user agent (starts with Mozilla/5.0)
- if a TOTP has been submitted ensure we first try TOTP auth, otherwise ensure PUSH auth is used first
